### PR TITLE
fix(sensors): prefix the device name to all sensors

### DIFF
--- a/custom_components/honeygain/binary_sensor.py
+++ b/custom_components/honeygain/binary_sensor.py
@@ -3,7 +3,7 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HoneygainData
@@ -46,7 +46,6 @@ class HoneygainDeviceBinarySensor(BinarySensorEntity):
         self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             configuration_url="https://dashboard.honeygain.com/profile",
-            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._generate_device_id())},
             manufacturer="Honeygain",
             name=self._device_data.get("title") or self._device_data.get("model"),

--- a/custom_components/honeygain/button.py
+++ b/custom_components/honeygain/button.py
@@ -17,7 +17,7 @@ async def async_setup_entry(
 ) -> None:
     """Button set up for HoneyGain."""
     honeygain_data: HoneygainData = hass.data[DOMAIN][entry.entry_id]
-    buttons: list[ButtonEntity] = [HoneygainPotButton(hass, honeygain_data)]
+    buttons: list[ButtonEntity] = [HoneygainPotButton(honeygain_data)]
     async_add_entities(buttons)
 
 
@@ -28,9 +28,8 @@ class HoneygainPotButton(ButtonEntity):
     button_description: ButtonEntityDescription
     _honeygain_data: HoneygainData
 
-    def __init__(self, hass: HomeAssistant, honeygain_data: HoneygainData) -> None:
+    def __init__(self, honeygain_data: HoneygainData) -> None:
         """Initialise a button."""
-        self.hass = hass
         self._honeygain_data = honeygain_data
         self.button_description = ButtonEntityDescription(
             key="open_lucky_pot",
@@ -40,14 +39,20 @@ class HoneygainPotButton(ButtonEntity):
         self.entity_id = f"button.{self.button_description.key}"
         self._attr_name = self.button_description.name
         self._attr_icon = self.button_description.icon
-        self._attr_unique_id = f"honeygain-{self._honeygain_data.user['referral_code']}-{self.button_description.key}"
+        self._attr_unique_id = self._generate_unique_id()
         self._attr_device_info = DeviceInfo(
             configuration_url="https://dashboard.honeygain.com/profile",
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._honeygain_data.user.get("referral_code"))},
+            identifiers={(DOMAIN, self._generate_button_id())},
             manufacturer="Honeygain",
             name="Account",
         )
+
+    def _generate_button_id(self):
+        return f"{DOMAIN}-{self._honeygain_data.user['referral_code']}"
+
+    def _generate_unique_id(self):
+        return f"{self._generate_button_id()}-{self.button_description.key}"
 
     def press(self) -> None:
         """Handle the button press."""

--- a/custom_components/honeygain/sensor.py
+++ b/custom_components/honeygain/sensor.py
@@ -46,20 +46,23 @@ class HoneygainAccountSensor(SensorEntity):
         sensor_description: SensorValueEntityDescription,
     ) -> None:
         """Create Sensor for displaying Honeygain account details."""
-        self.entity_description = sensor_description
         self._honeygain_data = honeygain_data
+        self.entity_description = sensor_description
         self._attr_unique_id = self._generate_unique_id()
-        self._attr_native_value = sensor_description.value(honeygain_data)
+        self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             configuration_url="https://dashboard.honeygain.com/profile",
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._honeygain_data.user.get("referral_code"))},
+            identifiers={(DOMAIN, self._generate_account_id())},
             manufacturer="Honeygain",
             name="Account",
         )
 
+    def _generate_account_id(self):
+        return f"{DOMAIN}-{self._honeygain_data.user['referral_code']}"
+
     def _generate_unique_id(self):
-        return f"honeygain-{self._honeygain_data.user['referral_code']}-{self.entity_description.key}"
+        return f"{self._generate_account_id()}-{self.entity_description.key}"
 
     def update(self) -> None:
         """Update Sensor data."""
@@ -81,13 +84,13 @@ class HoneygainDeviceSensor(SensorEntity):
         sensor_description: SensorValueEntityDescription,
     ) -> None:
         """Create Sensor for displaying Honeygain device details."""
-        self.entity_description = sensor_description
         self._honeygain_data = honeygain_data
         self._device_data = device_data
+        self.entity_description = sensor_description
         self._attr_unique_id = self._generate_unique_id()
+        self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             configuration_url="https://dashboard.honeygain.com/profile",
-            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._generate_device_id())},
             manufacturer="Honeygain",
             name=self._device_data.get("title") or self._device_data.get("model"),
@@ -95,7 +98,7 @@ class HoneygainDeviceSensor(SensorEntity):
         self._attr_native_value = self.entity_description.value(self._device_data)
 
     def _generate_device_id(self):
-        return f"honeygain-{self._device_data.get("ip")}"
+        return f"{DOMAIN}-{self._device_data.get("ip")}"
 
     def _generate_unique_id(self):
         return f"{self._generate_device_id()}-{self.entity_description.key}"


### PR DESCRIPTION
**Update Information**
HomeAssistant will not automatically re-generate the sensor IDs for devices, therefore manual actions are needed if you want to see the unique device IDs created by this update. 

_Examples_
`sensor.ip_address` -> `sensor.<device_name>_ip_address`
`sensor.last_active` -> `sensor.<device_name>_last_active`
`sensor.active_device_count` -> `sensor.account_active_device_count`

Either:
1. Delete and recreate the connection to Honeygain, this will refresh all devices in HomeAssistant and they will be added back with name-prefixed Sensor IDs
2. Within the view for each device (including Account), use the menu in the Top-Right to "Recreate Entity IDs"

⚠️ Regenerating IDs will cause automations / templates / dashboards to stop working until those entities are updated

fixes: #27 